### PR TITLE
Feat: Update index.css, added padding bottom to  .security-content

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -559,6 +559,7 @@ footer .right .footer-links a:nth-last-child(1)::after {
 
 .security-content {
   display: flex;
+  padding-bottom: 20px;
   width: 100%;
   justify-content: center;
   font-size: 19px;


### PR DESCRIPTION
Changed the padding of the security part.
<img width="948" alt="Rabby-page-not-fixed" src="https://github.com/RabbyHub/rabby.io/assets/161076076/139c78c4-aee4-45ec-9efd-035bb7329604">
<img width="949" alt="Rabby-page-fixed" src="https://github.com/RabbyHub/rabby.io/assets/161076076/44e96c20-ab21-4f78-af44-b8f139f74d75">

Note how in the first image there is no padding, and in the second image there is.

Changed the padding-bottom of .security-content, from 0px to 20px.
